### PR TITLE
expose all OSMI geometry; reorder TIGER CSV column

### DIFF
--- a/src/tasks.osmi.sh
+++ b/src/tasks.osmi.sh
@@ -22,27 +22,27 @@ echo "
 " | psql -U $pg_user osmi > osmi-tasks/intersections.csv
 
 echo "
-    COPY (select way_id, node_id from unconnected_major1) to stdout DELIMITER ',' HEADER CSV;
+    COPY (select way_id, node_id, ST_AsText(wkb_geometry) from unconnected_major1) to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user osmi > osmi-tasks/unconnected_major1.csv
 
 echo "
-    COPY (select way_id, node_id from unconnected_major2) to stdout DELIMITER ',' HEADER CSV;
+    COPY (select way_id, node_id, ST_AsText(wkb_geometry) from unconnected_major2) to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user osmi > osmi-tasks/unconnected_major2.csv
 
 echo "
-    COPY (select way_id, node_id from unconnected_major5) to stdout DELIMITER ',' HEADER CSV;
+    COPY (select way_id, node_id, ST_AsText(wkb_geometry) from unconnected_major5) to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user osmi > osmi-tasks/unconnected_major5.csv
 
 echo "
-    COPY (select way_id, node_id from unconnected_minor1) to stdout DELIMITER ',' HEADER CSV;
+    COPY (select way_id, node_id, ST_AsText(wkb_geometry) from unconnected_minor1) to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user osmi > osmi-tasks/unconnected_minor1.csv
 
 echo "
-    COPY (select way_id, node_id from unconnected_minor2) to stdout DELIMITER ',' HEADER CSV;
+    COPY (select way_id, node_id, ST_AsText(wkb_geometry) from unconnected_minor2) to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user osmi > osmi-tasks/unconnected_minor2.csv
 
 echo "
-    COPY (select way_id, node_id from unconnected_minor5) to stdout DELIMITER ',' HEADER CSV;
+    COPY (select way_id, node_id, ST_AsText(wkb_geometry) from unconnected_minor5) to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user osmi > osmi-tasks/unconnected_minor5.csv
 
 echo "

--- a/src/tasks.tigerdelta.sh
+++ b/src/tasks.tigerdelta.sh
@@ -13,9 +13,9 @@ fi
 mkdir tigerdelta-tasks
 
 echo "
-    COPY (select ST_AsText(wkb_geometry), name, way from ogrgeojson where name != '') to stdout DELIMITER ',' HEADER CSV;
+    COPY (select name, way, ST_AsText(wkb_geometry) from ogrgeojson where name != '') to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user tigerdelta > tigerdelta-tasks/tigerdelta-named.csv
 
 echo "
-    COPY (select ST_AsText(wkb_geometry), name, way from ogrgeojson where name = '') to stdout DELIMITER ',' HEADER CSV;
+    COPY (select name, way, ST_AsText(wkb_geometry) from ogrgeojson where name = '') to stdout DELIMITER ',' HEADER CSV;
 " | psql -U $pg_user tigerdelta > tigerdelta-tasks/tigerdelta-noname.csv


### PR DESCRIPTION
- OSMI unconnected_\* now have points in their task CSVs
- reordered TIGER CSVs to make geom column the final one, like other tasks
- confirmed all geometry columns are named `st_astext`
